### PR TITLE
Fix for OCP4

### DIFF
--- a/openshift/templates/nginx-runtime/Dockerfile
+++ b/openshift/templates/nginx-runtime/Dockerfile
@@ -15,7 +15,9 @@ COPY nginx.conf.template /tmp/
 COPY fetch_env.js /tmp/
 
 # Fix up permissions
-RUN chmod -R 0777 /tmp /var /run /etc /mnt /usr/libexec/s2i/
+RUN chmod -R 0777 /tmp /var /etc /mnt /usr/libexec/s2i/ && \
+    chmod 0777 /run 
+
 
 # Nginx runs on port 8080 by default
 EXPOSE 8080

--- a/openshift/templates/nginx-runtime/Dockerfile
+++ b/openshift/templates/nginx-runtime/Dockerfile
@@ -15,9 +15,7 @@ COPY nginx.conf.template /tmp/
 COPY fetch_env.js /tmp/
 
 # Fix up permissions
-RUN chmod -R 0777 /tmp /var /etc /mnt /usr/libexec/s2i/ && \
-    chmod 0777 /run 
-
+RUN chmod -R 0777 /tmp /var /etc /mnt /usr/libexec/s2i/ && chmod 0777 /run
 
 # Nginx runs on port 8080 by default
 EXPOSE 8080


### PR DESCRIPTION
OCP4 mounts OpenShift and k8s secrets under the `/run/secrets` directory automatically.  This causes the `chmod -R 0777` command to fail on the `/run` directory because the secret files are readonly.

This PR moves the `/run` directory to its own non-recursive`chmod` line.